### PR TITLE
1.6.17

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,9 +28,19 @@ src = [
   'pngwutil.c',
 ]
 
+defines = []
+if build_machine.cpu_family() == 'arm64' or cc.get_define('__ARM_NEON') != ''
+src += [
+  'arm/arm_init.c',
+  'arm/filter_neon_intrinsics.c',
+  'arm/filter_neon.S',
+]
+defines += [ '-DPNG_ARM_NEON_OPT=2' ]
+endif
 
 libpng = library('png',
   src,
+  c_args: defines,
   dependencies : [zdep, m_dep],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,13 @@
 project('libpng', 'c', version : '1.6.17', license : 'libpng')
 
-zdep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
-
 cc = meson.get_compiler('c')
+
+if cc.get_define('__ANDROID__') != ''
+zdep = declare_dependency(link_args: '-lz')
+else
+zdep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
+endif
+
 m_dep = cc.find_library('m', required : false)
 
 src = [


### PR DESCRIPTION
These changes enabled me to cross compile libpng for Android and ARM64

In my case I used a standalone Android ndk r16 toolchain like built like:
`make_standalone_toolchain.py --arch arm64 --api 21 --stl libc++`

and a cross file like:
```
[binaries]
name = 'android-arm64'
c = '/home/rib/local/android-arm64-toolchain-21/bin/aarch64-linux-android-clang'
cpp = '/home/rib/local/android-arm64-toolchain-21/bin/aarch64-linux-android-clang++'
ar = '/home/rib/local/android-arm64-toolchain-21/bin/aarch64-linux-android-ar'
ld = '/home/rib/local/android-arm64-toolchain-21/bin/aarch64-linux-android-ld'
strip = '/home/rib/local/android-arm64-toolchain-21/bin/aarch64-linux-android-strip'

[host_machine]
system = 'linux'
cpu_family = 'arm64'
cpu = 'arm64-v8a'
endian = 'little'
```