### PR TITLE
Fix build on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,17 @@ else
   zlib_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
 endif
 
+c_args = []
+
+if host_machine.system() == 'windows'
+  c_args += ['-DPNG_BUILD_DLL']
+endif
+
+libpng_deps = [
+        zlib_dep,
+        cc.find_library('m', required : false),
+]
+
 libpng = library('png', [
         'png.c',
         'pngerror.c',
@@ -27,10 +38,8 @@ libpng = library('png', [
         'pngwtran.c',
         'pngwutil.c',
     ],
-    dependencies : [
-        zlib_dep,
-        cc.find_library('m', required : false),
-    ],
+    dependencies : libpng_deps,
+    c_args: c_args,
 )
 
 configure_file(
@@ -42,6 +51,7 @@ configure_file(
 png_dep = declare_dependency(
     include_directories : include,
     link_with : libpng,
+    dependencies : libpng_deps,
 )
 
 png_test = executable('pngtest', 'pngtest.c', dependencies : png_dep)


### PR DESCRIPTION
For libpng to export its symbols on Windows, PNG_BUILD_DLL
needs to be defined.

The build was failing on Windows because the test couldn't
find the .lib to link against.

Also declare the dependencies of libpng in declare_dependency.