### PR TITLE
Fix compilation on ARM with NEON extension.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,10 +10,36 @@ else
   zlib_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
 endif
 
+src = [
+  'png.c',
+  'pngerror.c',
+  'pngget.c',
+  'pngmem.c',
+  'pngpread.c',
+  'pngread.c',
+  'pngrio.c',
+  'pngrtran.c',
+  'pngrutil.c',
+  'pngset.c',
+  'pngtrans.c',
+  'pngwio.c',
+  'pngwrite.c',
+  'pngwtran.c',
+  'pngwutil.c',
+]
 c_args = []
 
 if host_machine.system() == 'windows'
   c_args += ['-DPNG_BUILD_DLL']
+endif
+
+if host_machine.cpu_family() == 'arm64' or cc.get_define('__ARM_NEON') != ''
+  src += [
+    'arm/arm_init.c',
+    'arm/filter_neon_intrinsics.c',
+    'arm/filter_neon.S',
+  ]
+  c_args += ['-DPNG_ARM_NEON_OPT=2']
 endif
 
 libpng_deps = [
@@ -21,23 +47,8 @@ libpng_deps = [
         cc.find_library('m', required : false),
 ]
 
-libpng = library('png', [
-        'png.c',
-        'pngerror.c',
-        'pngget.c',
-        'pngmem.c',
-        'pngpread.c',
-        'pngread.c',
-        'pngrio.c',
-        'pngrtran.c',
-        'pngrutil.c',
-        'pngset.c',
-        'pngtrans.c',
-        'pngwio.c',
-        'pngwrite.c',
-        'pngwtran.c',
-        'pngwutil.c',
-    ],
+libpng = library('png',
+    src,
     dependencies : libpng_deps,
     c_args: c_args,
 )


### PR DESCRIPTION
This is consistent with what was done for libpng 1.6.17, except that I use host_machine.cpu_family() which seemed more appropriate.
See commit 5a86d76c685a7ed5dc027fa39ee24718a45bc3d2