### PR TITLE
Update to 1.6.35, install pkgconfig files and headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,10 +10,36 @@ else
   zlib_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
 endif
 
+src = [
+  'png.c',
+  'pngerror.c',
+  'pngget.c',
+  'pngmem.c',
+  'pngpread.c',
+  'pngread.c',
+  'pngrio.c',
+  'pngrtran.c',
+  'pngrutil.c',
+  'pngset.c',
+  'pngtrans.c',
+  'pngwio.c',
+  'pngwrite.c',
+  'pngwtran.c',
+  'pngwutil.c',
+]
 c_args = []
 
 if host_machine.system() == 'windows'
   c_args += ['-DPNG_BUILD_DLL']
+endif
+
+if host_machine.cpu_family() == 'arm64' or cc.get_define('__ARM_NEON') != ''
+  src += [
+    'arm/arm_init.c',
+    'arm/filter_neon_intrinsics.c',
+    'arm/filter_neon.S',
+  ]
+  c_args += ['-DPNG_ARM_NEON_OPT=2']
 endif
 
 libpng_deps = [
@@ -21,23 +47,8 @@ libpng_deps = [
         cc.find_library('m', required : false),
 ]
 
-libpng = library('png', [
-        'png.c',
-        'pngerror.c',
-        'pngget.c',
-        'pngmem.c',
-        'pngpread.c',
-        'pngread.c',
-        'pngrio.c',
-        'pngrtran.c',
-        'pngrutil.c',
-        'pngset.c',
-        'pngtrans.c',
-        'pngwio.c',
-        'pngwrite.c',
-        'pngwtran.c',
-        'pngwutil.c',
-    ],
+libpng = library('png',
+    src,
     dependencies : libpng_deps,
     c_args: c_args,
 )

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,17 @@ else
   zlib_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
 endif
 
+c_args = []
+
+if host_machine.system() == 'windows'
+  c_args += ['-DPNG_BUILD_DLL']
+endif
+
+libpng_deps = [
+        zlib_dep,
+        cc.find_library('m', required : false),
+]
+
 libpng = library('png', [
         'png.c',
         'pngerror.c',
@@ -27,10 +38,8 @@ libpng = library('png', [
         'pngwtran.c',
         'pngwutil.c',
     ],
-    dependencies : [
-        zlib_dep,
-        cc.find_library('m', required : false),
-    ],
+    dependencies : libpng_deps,
+    c_args: c_args,
 )
 
 configure_file(
@@ -42,6 +51,7 @@ configure_file(
 png_dep = declare_dependency(
     include_directories : include,
     link_with : libpng,
+    dependencies : libpng_deps,
 )
 
 png_test = executable('pngtest', 'pngtest.c', dependencies : png_dep)

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,11 @@
-project('libpng', 'c', license : 'libpng')
+project('libpng', 'c', version : '1.6.35', license : 'libpng')
+
+png_versions = meson.project_version().split('.')
+png_major_version = png_versions[0]
+png_minor_version = png_versions[1]
+png_micro_version = png_versions[2]
+png_libname = 'png@0@@1@'.format(png_major_version, png_minor_version)
+png_libversion = '@0@@1@.@2@.0'.format(png_major_version, png_minor_version, png_micro_version)
 
 cc = meson.get_compiler('c')
 
@@ -10,36 +17,10 @@ else
   zlib_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
 endif
 
-src = [
-  'png.c',
-  'pngerror.c',
-  'pngget.c',
-  'pngmem.c',
-  'pngpread.c',
-  'pngread.c',
-  'pngrio.c',
-  'pngrtran.c',
-  'pngrutil.c',
-  'pngset.c',
-  'pngtrans.c',
-  'pngwio.c',
-  'pngwrite.c',
-  'pngwtran.c',
-  'pngwutil.c',
-]
 c_args = []
 
 if host_machine.system() == 'windows'
   c_args += ['-DPNG_BUILD_DLL']
-endif
-
-if host_machine.cpu_family() == 'arm64' or cc.get_define('__ARM_NEON') != ''
-  src += [
-    'arm/arm_init.c',
-    'arm/filter_neon_intrinsics.c',
-    'arm/filter_neon.S',
-  ]
-  c_args += ['-DPNG_ARM_NEON_OPT=2']
 endif
 
 libpng_deps = [
@@ -47,16 +28,68 @@ libpng_deps = [
         cc.find_library('m', required : false),
 ]
 
-libpng = library('png',
-    src,
+libpng = library(png_libname, [
+        'png.c',
+        'pngerror.c',
+        'pngget.c',
+        'pngmem.c',
+        'pngpread.c',
+        'pngread.c',
+        'pngrio.c',
+        'pngrtran.c',
+        'pngrutil.c',
+        'pngset.c',
+        'pngtrans.c',
+        'pngwio.c',
+        'pngwrite.c',
+        'pngwtran.c',
+        'pngwutil.c',
+    ],
+    version : png_libversion,
     dependencies : libpng_deps,
     c_args: c_args,
+    install: true,
 )
 
+pngincsubdir = 'lib' + png_libname
+pngincludedir = join_paths(get_option('includedir'), pngincsubdir)
+
 configure_file(
-    configuration : configuration_data(),
     input : 'scripts/pnglibconf.h.prebuilt',
     output : 'pnglibconf.h',
+    copy: true,
+    install_dir : pngincludedir,
+    install: true
+)
+
+install_headers('png.h', 'pngconf.h', subdir : pngincsubdir)
+
+cdata = configuration_data()
+cdata.set('prefix', get_option('prefix'))
+cdata.set('exec_prefix', get_option('prefix'))
+cdata.set('libdir', '${prefix}/' + get_option('libdir'))
+cdata.set('includedir', '${prefix}/' + get_option('includedir'))
+cdata.set('PNGLIB_MAJOR', png_major_version)
+cdata.set('PNGLIB_MINOR', png_minor_version)
+cdata.set('PNGLIB_VERSION', meson.project_version())
+# FIXME: should auto-generate pkg-config file to get this right
+cdata.set('LIBS', '-lz')
+
+configure_file(
+    input : 'libpng.pc.in',
+    output : 'libpng16.pc',
+    configuration : cdata,
+    install_dir : join_paths(get_option('libdir'), 'pkgconfig'),
+    install : true,
+)
+
+# FIXME: this should be a symlink to libpng16.pc
+configure_file(
+    input : 'libpng.pc.in',
+    output : 'libpng.pc',
+    configuration : cdata,
+    install_dir : join_paths(get_option('libdir'), 'pkgconfig'),
+    install : true,
 )
 
 png_dep = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,48 @@
+project('libpng', 'c', license : 'libpng')
+
+cc = meson.get_compiler('c')
+
+include = include_directories('.')
+
+if cc.get_define('__ANDROID__') != ''
+  zlib_dep = cc.find_library('z')
+else
+  zlib_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
+endif
+
+libpng = library('png', [
+        'png.c',
+        'pngerror.c',
+        'pngget.c',
+        'pngmem.c',
+        'pngpread.c',
+        'pngread.c',
+        'pngrio.c',
+        'pngrtran.c',
+        'pngrutil.c',
+        'pngset.c',
+        'pngtrans.c',
+        'pngwio.c',
+        'pngwrite.c',
+        'pngwtran.c',
+        'pngwutil.c',
+    ],
+    dependencies : [
+        zlib_dep,
+        cc.find_library('m', required : false),
+    ],
+)
+
+configure_file(
+    configuration : configuration_data(),
+    input : 'scripts/pnglibconf.h.prebuilt',
+    output : 'pnglibconf.h',
+)
+
+png_dep = declare_dependency(
+    include_directories : include,
+    link_with : libpng,
+)
+
+png_test = executable('pngtest', 'pngtest.c', dependencies : png_dep)
+test('pngtest', png_test, args : files('pngtest.png'))

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = libpng-1.6.34
+
+source_url = ftp://ftp-osl.osuosl.org/pub/libpng/src/libpng16/libpng-1.6.34.tar.xz
+source_filename = libpng-1.6.34.tar.xz
+source_hash = 2f1e960d92ce3b3abd03d06dfec9637dfbd22febf107a536b44f7a47c60659f6


### PR DESCRIPTION
This also includes fixes for MSVC on Windows too, and it works well now.

macOS is still to be tested, f.ex., the dylib versioning ABI is probably incorrect.