### PR TITLE
Update to 1.6.35 release tarball

### DIFF
--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
-directory = libpng-1.6.34
+directory = libpng-1.6.35
 
-source_url = ftp://ftp-osl.osuosl.org/pub/libpng/src/libpng16/libpng-1.6.34.tar.xz
-source_filename = libpng-1.6.34.tar.xz
-source_hash = 2f1e960d92ce3b3abd03d06dfec9637dfbd22febf107a536b44f7a47c60659f6
+source_url = https://github.com/glennrp/libpng/archive/v1.6.35.tar.gz
+source_filename = libpng-1.6.35.tar.gz
+source_hash = 6d59d6a154ccbb772ec11772cb8f8beb0d382b61e7ccc62435bf7311c9f4b210


### PR DESCRIPTION
Note that the original file location `ftp://ftp-osl.osuosl.org/pub/libpng/src/libpng16/` was not updated with the `1.6.35` tarball as of writing.

So I switched it to https://github.com/glennrp/libpng/releases

I found this via libpng's official sourceforge page (https://libpng.sourceforge.io/):

> A "git" repository for libpng is available. You can access it by cloning git://git.code.sf.net/p/libpng/code or you can browse it at github.com/glennrp/libpng. or at sourceforge.net/p/libpng/code

I hope this qualifies as a trusted and reliable source.