### PR TITLE
Keep the old png_dep variable around too

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -112,6 +112,9 @@ libpng_dep = declare_dependency(
     link_with : libpng,
     dependencies : libpng_deps,
 )
+# Keep the older dependency name for backwards-compat with old-style
+# dependency(..., fallback ['libpng': 'png_dep'])
+png_dep = libpng_dep
 
 png_test = executable('pngtest', 'pngtest.c', dependencies : libpng_dep)
 test('pngtest', png_test, args : files('pngtest.png'))


### PR DESCRIPTION
Originally we used libpng_dep, then we switched to png_dep and now
we're back at libpng_dep. Unfortunately, some projects are using
png_dep and others are using libpng_dep because we flip-flopped. Just
keep both around in the build file.